### PR TITLE
[NEW] Convert zamgba as a library that can be consumed via other projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,26 @@ Please check comments in ``demo/first.zig`` for technical reasons.
 
 ### Can I reference your library as a dependency?
 
-Possible but not tested yet. The current structure is a bit irregular
-comparing with typical Zig project because my ``build.zig`` sets a
-cross compilation toolchain. When referencing ``zamgba`` as a dependency,
-the ``build.zig`` script must be updated as well. I haven't found a good
-approach yet.
+Yes. Please check example: https://github.com/fuzhouch/consumezamgba.
+
+I recommend we use git submodule to manage zamgba as dependency. This
+should fit the scenarios when developers have to work under a proxy.
+By the time this doc is written (2024-01), ``zig build`` does not work
+well with a proxy when downloading a remote package.
+
+The example project shows three steps to enable your project building
+a GBA rom:
+
+1. ``build.zig`` calls ``@import("zamgba").arm.addROM()`` to define
+   a target. The API defines proper target to build code targeting
+   ARM7tdmi. It also defines step to do ``objcopy``, which is required
+   to convert built ELF file to an ``.gba`` image that can be recognized
+   by mgba.
+2. In source code, define a ``gameHeader`` to register GBA rom header
+   required by GBA device. It must be done by calling
+   ``@import("zamgba").setupROMHeader()``.
+3. Define main() function entry point with ``export`` keyword. It is
+   required by ``zamgba`` to locate the entry point while booting.
+
+
+Enjoy!

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,13 @@
 const std = @import("std");
 const arm = @import("./src/build/arm.zig");
 
+fn libRoot() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}
+
+const GBALibFile = libRoot() ++ "/src/gba.zig";
+const FirstDemoRoot = libRoot() ++ "/demo/first.zig";
+
 // ====================================================================
 // The target definition and gba.ld are initialized from two projects:
 //
@@ -15,12 +22,13 @@ pub fn build(b: *std.Build) void {
     const gba_thumb_target = arm.buildGBAThumbTarget(b);
 
     // Core library
-    const lib = arm.addStaticLib(b, gba_thumb_target, optimize);
+    const lib = arm.addStaticLib(b, gba_thumb_target, optimize, "zamgba", GBALibFile);
     b.installArtifact(lib);
     b.default_step.dependOn(&lib.step);
 
     // Demos
-    arm.addROM(b, gba_thumb_target, optimize, "first", "demo/first.zig", lib);
+
+    arm.addROM(b, gba_thumb_target, optimize, "first", FirstDemoRoot, lib);
 
     // TODO Though not sure whether doable, let's keep unit test anyway.
     // Some logic should be able to run on devbox.

--- a/build.zig
+++ b/build.zig
@@ -1,83 +1,26 @@
 const std = @import("std");
+const arm = @import("./src/build/arm.zig");
 
 // ====================================================================
-// The target definition and gba.ld are from @wendigojaeger's project.
-// https://github.com/wendigojaeger/ZigGBA
+// The target definition and gba.ld are initialized from two projects:
 //
-
-fn buildGBAThumbTarget(b: *std.Build) std.Build.ResolvedTarget {
-    var query = std.zig.CrossTarget {
-        .cpu_arch = std.Target.Cpu.Arch.thumb,
-        .cpu_model = . { .explicit = &std.Target.arm.cpu.arm7tdmi },
-        .os_tag = .freestanding,
-    };
-    query.cpu_features_add.addFeature(@intFromEnum(std.Target.arm.Feature.thumb_mode));
-    return std.Build.resolveTargetQuery(b, query);
-}
-
-fn libRoot() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
-}
-const GBALinkerScript = libRoot() ++ "/src/gba.ld";
-const GBALibFile = libRoot() ++ "/src/gba.zig";
-
-// ====================================================================
-
-fn addExe(b: *std.Build,
-           target: std.Build.ResolvedTarget,
-           optimize: std.builtin.OptimizeMode,
-           executable: []const u8,
-           sourceRoot: []const u8,
-           linkToLib: *std.Build.Step.Compile) void {
-    const exe = b.addExecutable(.{
-        .name = executable,
-        .root_source_file = .{ .path = sourceRoot },
-        .target = target,
-        .optimize = optimize,
-    });
-    exe.setLinkerScriptPath(std.Build.LazyPath { .path = GBALinkerScript });
-    exe.root_module.addAnonymousImport( "gba", .{
-            .root_source_file = .{
-                .path = GBALibFile
-            }
-        });
-    exe.linkLibrary(linkToLib);
-
-    b.installArtifact(exe);
-
-    const objcopy_step = exe.addObjCopy(.{ .format = .bin });
-    const install_bin_step = b.addInstallBinFile(
-        objcopy_step.getOutputSource(),
-        b.fmt("{s}.gba", .{executable}));
-    install_bin_step.step.dependOn(&objcopy_step.step);
-    b.default_step.dependOn(&install_bin_step.step);
-}
-
-fn addStaticLib(b: *std.Build,
-                target: std.Build.ResolvedTarget,
-                optimize: std.builtin.OptimizeMode) *std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{
-        .name = "zamgba",
-        .root_source_file = .{ .path = GBALibFile },
-        .target = target,
-        .optimize = optimize,
-    });
-    lib.setLinkerScriptPath(std.Build.LazyPath { .path = GBALinkerScript });
-    return lib;
-}
-
+// https://github.com/wendigojaeger/ZigGBA
+// https://github.com/ryankurte/rust-gba
+//
+// It has been modified to fit the changes in zamgba.
+//
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const gba_thumb_target = buildGBAThumbTarget(b);
+    const gba_thumb_target = arm.buildGBAThumbTarget(b);
 
     // Core library
-    const lib = addStaticLib(b, gba_thumb_target, optimize);
+    const lib = arm.addStaticLib(b, gba_thumb_target, optimize);
     b.installArtifact(lib);
     b.default_step.dependOn(&lib.step);
 
     // Demos
-    addExe(b, gba_thumb_target, optimize, "first", "demo/first.zig", lib);
+    arm.addROM(b, gba_thumb_target, optimize, "first", "demo/first.zig", lib);
 
     // TODO Though not sure whether doable, let's keep unit test anyway.
     // Some logic should be able to run on devbox.

--- a/build.zig
+++ b/build.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
-const arm = @import("./src/build/arm.zig");
+
+// Pub is a must. User projects use it to reference to zamgba's build
+// script.
+pub const arm = @import("./src/build/arm.zig");
 
 fn libRoot() []const u8 {
     return std.fs.path.dirname(@src().file) orelse ".";
@@ -19,16 +22,15 @@ const FirstDemoRoot = libRoot() ++ "/demo/first.zig";
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    const gba_thumb_target = arm.buildGBAThumbTarget(b);
 
     // Core library
-    const lib = arm.addStaticLib(b, gba_thumb_target, optimize, "zamgba", GBALibFile);
+    const lib = arm.addStaticLib(b, optimize, "zamgba", GBALibFile);
     b.installArtifact(lib);
     b.default_step.dependOn(&lib.step);
 
     // Demos
-
-    arm.addROM(b, gba_thumb_target, optimize, "first", FirstDemoRoot, lib);
+    var first = arm.addROM(b, optimize, "first", FirstDemoRoot);
+    first.linkLibrary(lib);
 
     // TODO Though not sure whether doable, let's keep unit test anyway.
     // Some logic should be able to run on devbox.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,48 +3,9 @@
     .version = "0.1.0-dev",
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
-        // See `zig fetch --save <url>` for a command-line interface for adding dependencies.
-        //.example = .{
-        //    // When updating this field to a new URL, be sure to delete the corresponding
-        //    // `hash`, otherwise you are communicating that you expect to find the old hash at
-        //    // the new URL.
-        //    .url = "https://example.com/foo.tar.gz",
-        //
-        //    // This is computed from the file contents of the directory of files that is
-        //    // obtained after fetching `url` and applying the inclusion rules given by
-        //    // `paths`.
-        //    //
-        //    // This field is the source of truth; packages do not come from an `url`; they
-        //    // come from a `hash`. `url` is just one of many possible mirrors for how to
-        //    // obtain a package matching this `hash`.
-        //    //
-        //    // Uses the [multihash](https://multiformats.io/multihash/) format.
-        //    .hash = "...",
-        //
-        //    // When this is provided, the package is found in a directory relative to the
-        //    // build root. In this case the package's hash is irrelevant and therefore not
-        //    // computed. This field and `url` are mutually exclusive.
-        //    .path = "foo",
-        //},
     },
 
-    // Specifies the set of files and directories that are included in this package.
-    // Only files and directories listed here are included in the `hash` that
-    // is computed for this package.
-    // Paths are relative to the build root. Use the empty string (`""`) to refer to
-    // the build root itself.
-    // A directory listed here means that all files within, recursively, are included.
     .paths = .{
-        // This makes *all* files, recursively, included in this package. It is generally
-        // better to explicitly list the files and directories instead, to insure that
-        // fetching from tarballs, file system paths, and version control all result
-        // in the same contents hash.
         "",
-        // For example...
-        //"build.zig",
-        //"build.zig.zon",
-        //"src",
-        //"LICENSE",
-        //"README.md",
     },
 }

--- a/demo/first.zig
+++ b/demo/first.zig
@@ -1,4 +1,4 @@
-const gba = @import("gba");
+const gba = @import("zamgba");
 
 // The gameHeader is required at the beginning of GBA rom
 // with correct game name, game code, maker code and version.

--- a/src/build/arm.zig
+++ b/src/build/arm.zig
@@ -33,7 +33,7 @@ pub fn addROM(
         .optimize = optimize,
     });
     exe.setLinkerScriptPath(std.Build.LazyPath{ .path = GBALinkerScript });
-    exe.root_module.addAnonymousImport("gba", .{
+    exe.root_module.addAnonymousImport("zamgba", .{
         .root_source_file = .{
             .path = GBALibFile,
         },

--- a/src/build/arm.zig
+++ b/src/build/arm.zig
@@ -6,8 +6,8 @@ fn libRoot() []const u8 {
     return std.fs.path.dirname(@src().file) orelse ".";
 }
 
-const GBALinkerScript = libRoot() ++ "/../gba.ld";
 const GBALibFile = libRoot() ++ "/../gba.zig";
+const GBALinkerScript = libRoot() ++ "/../gba.ld";
 
 pub fn buildGBAThumbTarget(b: *std.Build) std.Build.ResolvedTarget {
     var query = std.zig.CrossTarget{
@@ -59,10 +59,12 @@ pub fn addStaticLib(
     b: *std.Build,
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
+    name: []const u8,
+    rootSource: []const u8,
 ) *std.Build.Step.Compile {
     const lib = b.addStaticLibrary(.{
-        .name = "zamgba",
-        .root_source_file = .{ .path = GBALibFile },
+        .name = name,
+        .root_source_file = .{ .path = rootSource },
         .target = target,
         .optimize = optimize,
     });

--- a/src/build/arm.zig
+++ b/src/build/arm.zig
@@ -1,0 +1,71 @@
+// This file includes code to be referenced by build scripts.
+// It defines build target for ARM7.
+const std = @import("std");
+
+fn libRoot() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}
+
+const GBALinkerScript = libRoot() ++ "/../gba.ld";
+const GBALibFile = libRoot() ++ "/../gba.zig";
+
+pub fn buildGBAThumbTarget(b: *std.Build) std.Build.ResolvedTarget {
+    var query = std.zig.CrossTarget{
+        .cpu_arch = std.Target.Cpu.Arch.thumb,
+        .cpu_model = .{ .explicit = &std.Target.arm.cpu.arm7tdmi },
+        .os_tag = .freestanding,
+    };
+    query.cpu_features_add.addFeature(@intFromEnum(std.Target.arm.Feature.thumb_mode));
+    return std.Build.resolveTargetQuery(b, query);
+}
+
+pub fn addROM(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    executable: []const u8,
+    sourceRoot: []const u8,
+    linkToLib: *std.Build.Step.Compile,
+) void {
+    const exe = b.addExecutable(.{
+        .name = executable,
+        .root_source_file = .{ .path = sourceRoot },
+        .target = target,
+        .optimize = optimize,
+    });
+    exe.setLinkerScriptPath(std.Build.LazyPath{ .path = GBALinkerScript });
+    exe.root_module.addAnonymousImport("gba", .{
+        .root_source_file = .{
+            .path = GBALibFile,
+        },
+    });
+    exe.linkLibrary(linkToLib);
+
+    b.installArtifact(exe);
+
+    const objcopy_step = exe.addObjCopy(.{ .format = .bin });
+    const install_bin_step = b.addInstallBinFile(
+        objcopy_step.getOutputSource(),
+        b.fmt(
+            "{s}.gba",
+            .{executable},
+        ),
+    );
+    install_bin_step.step.dependOn(&objcopy_step.step);
+    b.default_step.dependOn(&install_bin_step.step);
+}
+
+pub fn addStaticLib(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) *std.Build.Step.Compile {
+    const lib = b.addStaticLibrary(.{
+        .name = "zamgba",
+        .root_source_file = .{ .path = GBALibFile },
+        .target = target,
+        .optimize = optimize,
+    });
+    lib.setLinkerScriptPath(std.Build.LazyPath{ .path = GBALinkerScript });
+    return lib;
+}

--- a/src/gba.zig
+++ b/src/gba.zig
@@ -11,7 +11,6 @@
 // https://fabiensanglard.net/another_world_polygons_GBA/gbatech.html
 // https://github.com/gbadev-org/gbadoc
 // http://r32.github.io/other/2023-03-22-gba-dev.html
-
 const header = @import("header.zig");
 
 // Memory section for hardware read/write
@@ -154,7 +153,7 @@ fn copyDataToEWRAM() void {
 
 fn callUserMain() void {
     // The logic below just simply call main() function from client.
-    // Note that compiler can automatically detect the content of 
+    // Note that compiler can automatically detect the content of
     // main() is compiled ARM or Thumb instruction set. No need to do +1
     // manually.
     //
@@ -170,9 +169,8 @@ fn callUserMain() void {
         \\.cpu arm7tdmi
         \\ldr r0, =main
         \\bx r0
-        );
+    );
 }
-
 
 export fn _boot() linksection(".gba.boot") void {
     // After jumping from, _start(), we have reached _boot() function.
@@ -225,12 +223,11 @@ export fn _start() linksection(".gba.start") void {
     //    \\bx r0
     // _boot(); // ZigGBA's approach, which does not work.
 
-
     // The logic here is different with ZigGBA. ZigGBA combines startup
     // code in _start(). Thus just do 'bx pc + 1'. However it does not
     // work in our case, as the next thumb is interpreted as 'bx lr',
     // then it goes back to 'b 0x080000C0'. A loop back to header.
-    // This is wrong. 
+    // This is wrong.
     //
     // ZigGBA just directly does 'bx pc +1', putting _boot() at end of
     // assembly code in _start(). However in my case it always


### PR DESCRIPTION
1. Expose ARM build target definition as functions. Used by build.zig.
2. Use unified name, "zamgba",  as package name.
3. Add an example, https://github.com/fuzhouch/consumezamgba.